### PR TITLE
Refactor genome fitness calculation and improve code formatting

### DIFF
--- a/cerebraslib/genome/genome_purifyingonly.csl
+++ b/cerebraslib/genome/genome_purifyingonly.csl
@@ -3,7 +3,7 @@
 // byte 1
 // byte 2
 // byte 3
-// byte 4 COUNTER (u32, 4 bytes)
+// byte 4 DSTREAM_T COUNTER (u32, 4 bytes)
 // byte 5
 // byte 6
 // byte 7

--- a/cerebraslib/genome/genome_purifyingplus.csl
+++ b/cerebraslib/genome/genome_purifyingplus.csl
@@ -3,7 +3,7 @@
 // byte 1
 // byte 2
 // byte 3
-// byte 4 DSTREAM T COUNTER (u32, 4 bytes)
+// byte 4 DSTREAM_T COUNTER (u32, 4 bytes)
 // byte 5
 // byte 6
 // byte 7

--- a/cerebraslib/genome/genome_purifyingsweep.csl
+++ b/cerebraslib/genome/genome_purifyingsweep.csl
@@ -44,7 +44,6 @@ param rng: imported_module;
 
 // module imports =============================================================
 const math = @import_module("<math>");
-const random = @import_module("<random>");
 
 const compconf = @import_module("<compconf>");
 comptime { // access via get_value for logging...
@@ -67,7 +66,6 @@ const hstrat_T_dilation = compconf.get_value_or(
     @as(u32, 1),
 );
 
-
 const bitmanip = @import_module("cerebraslib/bitmanip.csl");
 const opscalar = @import_module("cerebraslib/opscalar.csl");
 
@@ -81,8 +79,12 @@ const nTraitVals: u16 = 1;
 const hasImmClobber: bool = false;
 
 // internal functions =========================================================
+fn _calc_fitness_of(genome: genomePtr_t) f32 {
+    return @ptrcast(*f32, genome).*;
+}
+
 fn _apply_mutation(genome: genomePtr_t) void {
-    var mutated = calc_fitness_of(genome);
+    var mutated = _calc_fitness_of(genome);
 
     if (rng.next() == 1) {
         mutated += 1.0 + @as(f32, rng.next() & 0xFF);
@@ -120,11 +122,12 @@ fn _step_instrumentation(genome: genomePtr_t) void {
 
 // public API =================================================================
 fn elapse_inheritance_of(genome: genomePtr_t) void {
-    _apply_mutation(genome); _step_instrumentation(genome);
+    _apply_mutation(genome);
+    _step_instrumentation(genome);
 }
 
 fn calc_fitness_of(genome: genomePtr_t) f32 {
-    return @ptrcast(*f32, genome).* * 8.0;  // times eight allows sanity check
+    return _calc_fitness_of(genome) * 8.0;  // times eight allows sanity check
 }
 
 fn get_trait_value(genome: genomePtr_t) u32 {
@@ -137,7 +140,9 @@ fn initialize_one(genome: genomePtr_t) void {
     @ptrcast(*f32, genome).* = 0.0;
     @ptrcast([*]u32, genome)[1] = 0;
     @ptrcast([*]u32, genome)[4] = 0;
-    for (@range(u16, S)) |_| { _do_step_instrumentation(genome); }
+    for (@range(u16, S)) |_| {
+        _do_step_instrumentation(genome);
+    }
 }
 
-fn clobber_immigrant(resident: genomePtr_t, immigrant: genomePtr_t) void { }
+fn clobber_immigrant(resident: genomePtr_t, immigrant: genomePtr_t) void {}


### PR DESCRIPTION
## Summary
This PR refactors the fitness calculation logic in the genome modules and applies consistent code formatting improvements across the codebase.

## Key Changes
- **Extracted internal fitness calculation**: Created a new `_calc_fitness_of()` internal function that performs the raw fitness pointer cast, reducing code duplication
- **Updated public API**: Modified `calc_fitness_of()` to use the new internal function, maintaining the 8x multiplier for sanity checking
- **Fixed mutation logic**: Updated `_apply_mutation()` to call the new `_calc_fitness_of()` instead of the public `calc_fitness_of()` function
- **Code formatting improvements**:
  - Removed unused `random` module import
  - Cleaned up extra blank lines
  - Reformatted multi-statement lines for better readability (e.g., `_apply_mutation()` and `_step_instrumentation()` calls)
  - Standardized function brace formatting in `clobber_immigrant()`
  - Fixed loop formatting in `initialize_one()`
- **Documentation updates**: Corrected inconsistent naming in comments (`DSTREAM T` → `DSTREAM_T`) across genome modules

## Implementation Details
The refactoring separates concerns by having `_calc_fitness_of()` handle the low-level pointer casting, while `calc_fitness_of()` applies the domain-specific scaling factor. This makes the code more maintainable and reduces the risk of inconsistencies when the fitness calculation is used in different contexts.

https://claude.ai/code/session_01P6KDuL92hRSUyVCdP9aFVr